### PR TITLE
Remove gap from CSP

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="theme-color" content="#2196f3">
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data:">
   <title>Framework7 Feeds</title>
   <link rel="stylesheet" href="framework7/css/framework7.min.css">
   <link rel="stylesheet" href="../dist/framework7.feeds.min.css">


### PR DESCRIPTION
In the recent release of Cordova CLI 11.0.0 the newest App Hello World template 6.0.0 is used for all new projects, in which the `gap:` (which was needed when using UIWebView on iOS) from the Content Security Policy has been completely removed.

So I thought of making the same change in framework7-plugin-feeds index.html file.